### PR TITLE
chore: add poetry-lock-check pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,3 +69,14 @@ repos:
         types: [python]
         pass_filenames: false
         require_serial: true
+
+  # poetry check - ensure pyproject.toml and poetry.lock are in sync
+  - repo: local
+    hooks:
+      - id: poetry-lock-check
+        name: poetry lock check
+        language: system
+        entry: poetry
+        args: ["check", "--lock"]
+        pass_filenames: false
+        files: ^(pyproject\.toml|poetry\.lock)$


### PR DESCRIPTION
Ensure pyproject.toml and poetry.lock are always in sync before committing. Prevents CI failures caused by mismatched lock file (as seen in PR #14).