### PR TITLE
feat: task 1.6 - import and prepare deidentified data

### DIFF
--- a/docs/planning/TASK_BREAKDOWN.cn.md
+++ b/docs/planning/TASK_BREAKDOWN.cn.md
@@ -119,7 +119,9 @@
 
 ---
 
-### 任务 1.6：导入和清洗脱敏数据
+### 任务 1.6：导入和清洗脱敏数据 🚧 *进行中*
+
+> **GitHub Issue**: [#16](https://github.com/DerekJi/VedaAide.py/issues/16) | **分支**: `feat/issue-16-import-deidentified-data`
 
 **目标**
 - [ ] 导入用户自有数据或使用任务 1.5 中的公开数据集

--- a/docs/planning/TASK_BREAKDOWN.en.md
+++ b/docs/planning/TASK_BREAKDOWN.en.md
@@ -119,7 +119,9 @@ This document breaks down each phase of the project roadmap into specific, actio
 
 ---
 
-### Task 1.6: Import and Prepare Deidentified Data
+### Task 1.6: Import and Prepare Deidentified Data 🚧 *In Progress*
+
+> **GitHub Issue**: [#16](https://github.com/DerekJi/VedaAide.py/issues/16) | **Branch**: `feat/issue-16-import-deidentified-data`
 
 **Objective**
 - [ ] Import user's own data or use public datasets from Task 1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,14 @@ disable = [
     "W1203",  # logging-fstring-interpolation (design choice for scripts)
 ]
 
+[tool.pylint.typecheck]
+# These are optional runtime dependencies not installed in the dev/CI environment.
+# They are guarded by try/except ImportError in production code.
+ignored-modules = [
+    "qdrant_client",
+    "llama_index",
+]
+
 [tool.pylint.format]
 max-line-length = 100
 indent-string = "    "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,13 @@ exclude = [
 module = "translatepy.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+# qdrant_client and llama_index are optional runtime deps; the try/except
+# ImportError fallbacks use `# type: ignore[assignment]` which may be
+# flagged as unused when ignore_missing_imports treats them as Any.
+module = "src.core.data.indexer"
+warn_unused_ignores = false
+
 [tool.pylint.messages_control]
 disable = [
     "C0111",  # missing-docstring (handled by our standards)

--- a/scripts/data/import_deidentified_data.py
+++ b/scripts/data/import_deidentified_data.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Import and deidentify data, then index into Qdrant.
+
+Pipeline:
+  1. Load public sample data (resumes, job postings)
+  2. Apply PII deidentification via Deidentifier
+  3. Build DocumentRecord objects with versioning metadata
+  4. Index into Qdrant via DocumentIndexer (LlamaIndex)
+  5. Write index manifest for traceability
+
+Usage:
+    poetry run python scripts/data/import_deidentified_data.py
+    poetry run python scripts/data/import_deidentified_data.py --dry-run
+    poetry run python scripts/data/import_deidentified_data.py --qdrant-url http://localhost:6333
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Allow running from project root
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from scripts.data.load_public_samples import PublicSampleLoader  # noqa: E402
+from src.core.data.indexer import (  # noqa: E402
+    DEFAULT_COLLECTION_NAME,
+    DocumentIndexer,
+    DocumentRecord,
+)
+from src.core.retrieval.deidentifier import Deidentifier  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+MANIFEST_PATH = "data/working_datasets/index_manifest.json"
+MIN_DOCUMENTS = 10
+
+
+def build_resume_record(raw: Dict[str, Any], deidentifier: Deidentifier) -> DocumentRecord:
+    """Convert a raw resume dict into a deidentified DocumentRecord."""
+    content = raw.get("content", "")
+    deidentified_content = deidentifier.deidentify(content)
+    metadata = {k: v for k, v in raw.items() if k not in ("content",)}
+    return DocumentRecord(
+        doc_id=raw["id"],
+        doc_type="resume",
+        content=deidentified_content,
+        metadata=metadata,
+    )
+
+
+def build_job_record(raw: Dict[str, Any], deidentifier: Deidentifier) -> DocumentRecord:
+    """Convert a raw job posting dict into a deidentified DocumentRecord."""
+    # Flatten structured fields into a single content string
+    requirements = "\n".join(f"- {r}" for r in raw.get("requirements", []))
+    benefits = "\n".join(f"- {b}" for b in raw.get("benefits", []))
+    content = (
+        f"Title: {raw.get('title', '')}\n"
+        f"Company: {raw.get('company', '')}\n"
+        f"Location: {raw.get('location', '')}\n\n"
+        f"Description:\n{raw.get('description', '')}\n\n"
+        f"Requirements:\n{requirements}\n\n"
+        f"Benefits:\n{benefits}"
+    )
+    deidentified_content = deidentifier.deidentify(content)
+    metadata = {
+        k: v for k, v in raw.items() if k not in ("description", "requirements", "benefits")
+    }
+    return DocumentRecord(
+        doc_id=raw["id"],
+        doc_type="job_posting",
+        content=deidentified_content,
+        metadata=metadata,
+    )
+
+
+def load_and_deidentify(
+    data_dir: str = "data/public_samples",
+) -> List[DocumentRecord]:
+    """Load all sample data and apply deidentification.
+
+    Args:
+        data_dir: Path to directory containing sample JSON files.
+
+    Returns:
+        List of deidentified DocumentRecord objects.
+    """
+    loader = PublicSampleLoader(data_dir=data_dir)
+    deidentifier = Deidentifier()
+
+    records: List[DocumentRecord] = []
+
+    logger.info("Loading resumes...")
+    resumes = loader.load_resumes()
+    for raw in resumes:
+        records.append(build_resume_record(raw, deidentifier))
+    logger.info("Loaded %d resumes", len(resumes))
+
+    logger.info("Loading job postings...")
+    jobs = loader.load_job_postings()
+    for raw in jobs:
+        records.append(build_job_record(raw, deidentifier))
+    logger.info("Loaded %d job postings", len(jobs))
+
+    logger.info("Total documents after deidentification: %d", len(records))
+    return records
+
+
+def verify_deidentification(records: List[DocumentRecord]) -> bool:
+    """Verify no raw PII patterns remain in any record's content.
+
+    Args:
+        records: List of DocumentRecord objects to verify.
+
+    Returns:
+        True if all records pass verification.
+    """
+    deidentifier = Deidentifier()
+    all_clean = True
+    for rec in records:
+        matches = deidentifier.detect(rec.content)
+        if matches:
+            logger.warning(
+                "PII detected in %s (%s): %s",
+                rec.doc_id,
+                rec.doc_type,
+                [m.type.value for m in matches],
+            )
+            all_clean = False
+    return all_clean
+
+
+def print_summary(records: List[DocumentRecord]) -> None:
+    """Print a human-readable summary of loaded records."""
+    by_type: Dict[str, int] = {}
+    for rec in records:
+        by_type[rec.doc_type] = by_type.get(rec.doc_type, 0) + 1
+    print("\n--- Document Summary ---")
+    for doc_type, count in sorted(by_type.items()):
+        print(f"  {doc_type}: {count}")
+    print(f"  TOTAL: {len(records)}")
+    print("------------------------\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Import and index deidentified data into Qdrant")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Load and deidentify data but skip Qdrant indexing",
+    )
+    parser.add_argument(
+        "--qdrant-url",
+        default="http://localhost:6333",
+        help="Qdrant server URL (default: http://localhost:6333)",
+    )
+    parser.add_argument(
+        "--collection",
+        default=DEFAULT_COLLECTION_NAME,
+        help=f"Qdrant collection name (default: {DEFAULT_COLLECTION_NAME})",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default="data/public_samples",
+        help="Directory containing sample JSON files",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=MANIFEST_PATH,
+        help=f"Output path for index manifest (default: {MANIFEST_PATH})",
+    )
+    args = parser.parse_args()
+
+    # Step 1: Load and deidentify
+    records = load_and_deidentify(data_dir=args.data_dir)
+    print_summary(records)
+
+    # Step 2: Verify deidentification
+    logger.info("Verifying deidentification...")
+    if not verify_deidentification(records):
+        logger.warning("Some records may still contain PII - check logs above")
+    else:
+        logger.info("Deidentification verified: no PII detected")
+
+    # Step 3: Check minimum document count
+    if len(records) < MIN_DOCUMENTS:
+        logger.error("Insufficient documents: need %d, got %d", MIN_DOCUMENTS, len(records))
+        return 1
+
+    if args.dry_run:
+        logger.info("--dry-run: skipping Qdrant indexing")
+        print(json.dumps([{"doc_id": r.doc_id, "doc_type": r.doc_type} for r in records], indent=2))
+        return 0
+
+    # Step 4: Index into Qdrant
+    indexer = DocumentIndexer(
+        qdrant_url=args.qdrant_url,
+        collection_name=args.collection,
+    )
+    logger.info(
+        "Indexing %d documents into Qdrant collection '%s'...", len(records), args.collection
+    )
+    stats = indexer.index_documents(records)
+
+    print("\n--- Index Stats ---")
+    print(f"  Collection  : {stats.collection}")
+    print(f"  Indexed     : {stats.indexed}")
+    print(f"  Errors      : {stats.errors}")
+    print(f"  Total vectors: {stats.total_vectors}")
+    print("-------------------\n")
+
+    # Step 5: Save manifest
+    indexer.save_manifest(stats, records, args.manifest)
+    logger.info("Pipeline complete.")
+
+    return 0 if stats.errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/data/__init__.py
+++ b/src/core/data/__init__.py
@@ -27,6 +27,7 @@ from .data_loader import (
     KaggleDataSource,
     StaticDataSource,
 )
+from .indexer import DocumentIndexer, DocumentRecord, IndexStats
 
 __all__ = [
     "DataLoader",
@@ -36,4 +37,7 @@ __all__ = [
     "GeneratedDataSource",
     "KaggleDataSource",
     "HuggingFaceDataSource",
+    "DocumentIndexer",
+    "DocumentRecord",
+    "IndexStats",
 ]

--- a/src/core/data/indexer.py
+++ b/src/core/data/indexer.py
@@ -1,0 +1,244 @@
+"""Document indexer for VedaAide using LlamaIndex and Qdrant.
+
+Builds a multi-dimensional data model from deidentified documents and
+indexes them into a Qdrant vector store for semantic retrieval.
+
+Usage:
+    >>> from src.core.data.indexer import DocumentIndexer
+    >>> indexer = DocumentIndexer()
+    >>> stats = indexer.index_documents(documents)
+    >>> print(stats)  # {"indexed": 10, "collection": "vedaaide_docs", ...}
+"""
+
+import hashlib
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Lazy imports — only resolved at call time to avoid hard runtime dependency.
+# They are imported at module level as None so tests can patch them.
+try:
+    from llama_index.core import Document, Settings, VectorStoreIndex
+    from llama_index.vector_stores.qdrant import QdrantVectorStore
+except ImportError:  # pragma: no cover
+    Document = None  # type: ignore
+    Settings = None  # type: ignore
+    VectorStoreIndex = None  # type: ignore
+    QdrantVectorStore = None  # type: ignore
+
+# Default Qdrant settings
+DEFAULT_QDRANT_URL = "http://localhost:6333"
+DEFAULT_COLLECTION_NAME = "vedaaide_docs"
+DEFAULT_EMBED_MODEL = "BAAI/bge-small-en-v1.5"
+EMBED_DIM = 384  # bge-small-en-v1.5 output dimension
+
+
+@dataclass
+class DocumentRecord:
+    """A normalized document ready for indexing."""
+
+    doc_id: str
+    doc_type: str  # "resume" | "job_posting" | "qa"
+    content: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    version: str = ""
+    indexed_at: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.version:
+            self.version = self._compute_hash()
+        if not self.indexed_at:
+            self.indexed_at = datetime.now(timezone.utc).isoformat()
+
+    def _compute_hash(self) -> str:
+        return hashlib.sha256(self.content.encode()).hexdigest()[:12]
+
+
+@dataclass
+class IndexStats:
+    """Statistics from an indexing run."""
+
+    collection: str
+    indexed: int
+    skipped: int
+    errors: int
+    total_vectors: int
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+class DocumentIndexer:
+    """Index deidentified documents into Qdrant via LlamaIndex.
+
+    Uses HuggingFace BGE-small embeddings (local, no API key required) and
+    stores documents in a Qdrant collection with full metadata.
+
+    Args:
+        qdrant_url: URL of the Qdrant server.
+        collection_name: Name of the Qdrant collection.
+        embed_model_name: HuggingFace model name for embeddings.
+    """
+
+    def __init__(
+        self,
+        qdrant_url: str = DEFAULT_QDRANT_URL,
+        collection_name: str = DEFAULT_COLLECTION_NAME,
+        embed_model_name: str = DEFAULT_EMBED_MODEL,
+    ) -> None:
+        self.qdrant_url = qdrant_url
+        self.collection_name = collection_name
+        self.embed_model_name = embed_model_name
+        self._qdrant_client: Optional[Any] = None
+        self._embed_model: Optional[Any] = None
+        self._vector_store: Optional[Any] = None
+
+    def _get_qdrant_client(self) -> Any:
+        if self._qdrant_client is None:
+            from qdrant_client import QdrantClient  # pylint: disable=import-outside-toplevel
+
+            self._qdrant_client = QdrantClient(url=self.qdrant_url)
+            logger.info("Connected to Qdrant at %s", self.qdrant_url)
+        return self._qdrant_client
+
+    def _get_embed_model(self) -> Any:
+        if self._embed_model is None:
+            # pylint: disable-next=import-outside-toplevel
+            from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+
+            self._embed_model = HuggingFaceEmbedding(model_name=self.embed_model_name)
+            logger.info("Loaded embedding model: %s", self.embed_model_name)
+        return self._embed_model
+
+    def _ensure_collection(self) -> None:
+        from qdrant_client.models import (  # pylint: disable=import-outside-toplevel
+            Distance,
+            VectorParams,
+        )
+
+        client = self._get_qdrant_client()
+        existing = {c.name for c in client.get_collections().collections}
+        if self.collection_name not in existing:
+            client.create_collection(
+                collection_name=self.collection_name,
+                vectors_config=VectorParams(size=EMBED_DIM, distance=Distance.COSINE),
+            )
+            logger.info("Created Qdrant collection: %s", self.collection_name)
+
+    def _build_llama_documents(self, records: List[DocumentRecord]) -> List[Any]:
+        docs = []
+        for rec in records:
+            meta = {
+                "doc_id": rec.doc_id,
+                "doc_type": rec.doc_type,
+                "version": rec.version,
+                "indexed_at": rec.indexed_at,
+                **rec.metadata,
+            }
+            docs.append(Document(text=rec.content, metadata=meta, id_=rec.doc_id))
+        return docs
+
+    def index_documents(self, records: List[DocumentRecord]) -> IndexStats:
+        """Index a list of DocumentRecords into Qdrant.
+
+        Args:
+            records: List of deidentified document records.
+
+        Returns:
+            IndexStats with counts and collection info.
+        """
+        self._ensure_collection()
+        client = self._get_qdrant_client()
+        embed_model = self._get_embed_model()
+
+        Settings.embed_model = embed_model
+        Settings.llm = None  # no LLM needed for indexing
+
+        vector_store = QdrantVectorStore(
+            client=client,
+            collection_name=self.collection_name,
+        )
+
+        llama_docs = self._build_llama_documents(records)
+        indexed = 0
+        errors = 0
+
+        for doc in llama_docs:
+            try:
+                VectorStoreIndex.from_documents(
+                    [doc],
+                    vector_store=vector_store,
+                    show_progress=False,
+                )
+                indexed += 1
+                logger.debug("Indexed doc: %s", doc.id_)
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                errors += 1
+                logger.error("Failed to index %s: %s", doc.id_, exc)
+
+        total = client.get_collection(self.collection_name).vectors_count or 0
+
+        stats = IndexStats(
+            collection=self.collection_name,
+            indexed=indexed,
+            skipped=len(records) - indexed - errors,
+            errors=errors,
+            total_vectors=total,
+        )
+        logger.info(
+            "Indexing complete: %d indexed, %d errors, %d total vectors",
+            indexed,
+            errors,
+            total,
+        )
+        return stats
+
+    def get_collection_stats(self) -> Dict[str, Any]:
+        """Return current collection statistics from Qdrant."""
+        client = self._get_qdrant_client()
+        info = client.get_collection(self.collection_name)
+        return {
+            "collection": self.collection_name,
+            "vectors_count": info.vectors_count,
+            "indexed_vectors_count": info.indexed_vectors_count,
+            "status": str(info.status),
+        }
+
+    def collection_exists(self) -> bool:
+        """Return True if the collection already exists in Qdrant."""
+        client = self._get_qdrant_client()
+        existing = {c.name for c in client.get_collections().collections}
+        return self.collection_name in existing
+
+    def save_manifest(
+        self, stats: IndexStats, records: List[DocumentRecord], output_path: str
+    ) -> None:
+        """Write an index manifest JSON file for version tracking.
+
+        Args:
+            stats: IndexStats from the indexing run.
+            records: List of indexed records.
+            output_path: File path to write the manifest.
+        """
+        manifest = {
+            "version": "1.0",
+            "generated_at": stats.timestamp,
+            "collection": stats.collection,
+            "summary": asdict(stats),
+            "documents": [
+                {
+                    "doc_id": r.doc_id,
+                    "doc_type": r.doc_type,
+                    "version": r.version,
+                    "indexed_at": r.indexed_at,
+                }
+                for r in records
+            ],
+        }
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2, ensure_ascii=False)
+        logger.info("Manifest saved to %s", output_path)

--- a/src/core/data/indexer.py
+++ b/src/core/data/indexer.py
@@ -26,10 +26,10 @@ try:
     from llama_index.core import Document, Settings, VectorStoreIndex
     from llama_index.vector_stores.qdrant import QdrantVectorStore
 except ImportError:  # pragma: no cover
-    Document = None  # type: ignore
-    Settings = None  # type: ignore
-    VectorStoreIndex = None  # type: ignore
-    QdrantVectorStore = None  # type: ignore
+    Document = None  # type: ignore[misc,assignment]
+    Settings = None  # type: ignore[misc,assignment]
+    VectorStoreIndex = None  # type: ignore[misc,assignment]
+    QdrantVectorStore = None  # type: ignore[misc,assignment]
 
 # Default Qdrant settings
 DEFAULT_QDRANT_URL = "http://localhost:6333"

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration test package."""

--- a/tests/integration/test_data_import.py
+++ b/tests/integration/test_data_import.py
@@ -122,6 +122,7 @@ class TestDocumentIndexer:
             patch.object(indexer, "_get_qdrant_client", return_value=mock_qdrant_client),
             patch.object(indexer, "_get_embed_model", return_value=mock_embed),
             patch.object(indexer, "_ensure_collection"),
+            patch("src.core.data.indexer.Document", MagicMock()),
             patch("src.core.data.indexer.Settings", mock_settings),
             patch("src.core.data.indexer.VectorStoreIndex", mock_vsi),
             patch("src.core.data.indexer.QdrantVectorStore", mock_qvs),

--- a/tests/integration/test_data_import.py
+++ b/tests/integration/test_data_import.py
@@ -1,0 +1,204 @@
+"""Integration tests for data import and Qdrant indexing pipeline (Task 1.6).
+
+These tests mock Qdrant and LlamaIndex to verify the pipeline logic
+without requiring a running Qdrant server or embedding model.
+"""
+
+import json
+from typing import Any, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.core.data.indexer import DocumentIndexer, DocumentRecord, IndexStats
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_records() -> List[DocumentRecord]:
+    """Provide 12 minimal DocumentRecord objects (> MIN_DOCUMENTS = 10)."""
+    records = []
+    for i in range(1, 13):
+        records.append(
+            DocumentRecord(
+                doc_id=f"doc_{i:03d}",
+                doc_type="resume" if i % 2 == 0 else "job_posting",
+                content=f"Sample content for document {i}. No PII here.",
+                metadata={"source": "test"},
+            )
+        )
+    return records
+
+
+@pytest.fixture
+def mock_qdrant_client() -> MagicMock:
+    """Mock QdrantClient."""
+    client = MagicMock()
+    collection_mock = MagicMock()
+    collection_mock.vectors_count = 12
+    collection_mock.indexed_vectors_count = 12
+    collection_mock.status = "green"
+    client.get_collection.return_value = collection_mock
+    client.get_collections.return_value = MagicMock(collections=[])
+    return client
+
+
+# ---------------------------------------------------------------------------
+# DocumentRecord tests
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentRecord:
+    def test_auto_version_hash(self) -> None:
+        rec = DocumentRecord(doc_id="r1", doc_type="resume", content="hello world")
+        assert len(rec.version) == 12, "Version hash should be 12 chars"
+
+    def test_auto_indexed_at(self) -> None:
+        rec = DocumentRecord(doc_id="r1", doc_type="resume", content="test")
+        assert rec.indexed_at.endswith("+00:00") or "T" in rec.indexed_at
+
+    def test_same_content_same_version(self) -> None:
+        r1 = DocumentRecord(doc_id="a", doc_type="resume", content="same")
+        r2 = DocumentRecord(doc_id="b", doc_type="resume", content="same")
+        assert r1.version == r2.version
+
+    def test_different_content_different_version(self) -> None:
+        r1 = DocumentRecord(doc_id="a", doc_type="resume", content="aaa")
+        r2 = DocumentRecord(doc_id="b", doc_type="resume", content="bbb")
+        assert r1.version != r2.version
+
+
+# ---------------------------------------------------------------------------
+# DocumentIndexer tests
+# ---------------------------------------------------------------------------
+
+
+# pylint: disable=redefined-outer-name
+class TestDocumentIndexer:
+    # pylint: disable-next=redefined-outer-name
+    def test_collection_exists_false(self, mock_qdrant_client: MagicMock) -> None:
+        """Returns False when collection is not in Qdrant."""
+        indexer = DocumentIndexer()
+        with patch.object(indexer, "_get_qdrant_client", return_value=mock_qdrant_client):
+            assert indexer.collection_exists() is False
+
+    # pylint: disable-next=redefined-outer-name
+    def test_collection_exists_true(self, mock_qdrant_client: MagicMock) -> None:
+        """Returns True when collection is already present."""
+        existing = MagicMock()
+        existing.name = "vedaaide_docs"
+        mock_qdrant_client.get_collections.return_value = MagicMock(collections=[existing])
+        indexer = DocumentIndexer()
+        with patch.object(indexer, "_get_qdrant_client", return_value=mock_qdrant_client):
+            assert indexer.collection_exists() is True
+
+    # pylint: disable-next=redefined-outer-name
+    def test_get_collection_stats(self, mock_qdrant_client: MagicMock) -> None:
+        """get_collection_stats returns expected keys."""
+        indexer = DocumentIndexer()
+        with patch.object(indexer, "_get_qdrant_client", return_value=mock_qdrant_client):
+            stats = indexer.get_collection_stats()
+        assert "collection" in stats
+        assert "vectors_count" in stats
+        assert "status" in stats
+
+    def test_index_documents_success(
+        self,
+        sample_records: List[DocumentRecord],
+        mock_qdrant_client: MagicMock,
+    ) -> None:
+        """index_documents returns correct stats after successful run."""
+        indexer = DocumentIndexer()
+        mock_embed = MagicMock()
+        mock_settings = MagicMock()
+        mock_vsi = MagicMock()
+        mock_vsi.from_documents.return_value = MagicMock()
+        mock_qvs = MagicMock()
+
+        with (
+            patch.object(indexer, "_get_qdrant_client", return_value=mock_qdrant_client),
+            patch.object(indexer, "_get_embed_model", return_value=mock_embed),
+            patch.object(indexer, "_ensure_collection"),
+            patch("src.core.data.indexer.Settings", mock_settings),
+            patch("src.core.data.indexer.VectorStoreIndex", mock_vsi),
+            patch("src.core.data.indexer.QdrantVectorStore", mock_qvs),
+        ):
+            stats = indexer.index_documents(sample_records)
+
+        assert stats.indexed == len(sample_records)
+        assert stats.errors == 0
+        assert stats.collection == "vedaaide_docs"
+
+    def test_save_manifest(
+        self,
+        tmp_path: Any,
+        sample_records: List[DocumentRecord],
+    ) -> None:
+        """save_manifest writes a valid JSON file with expected fields."""
+        manifest_path = str(tmp_path / "manifest.json")
+        stats = IndexStats(
+            collection="vedaaide_docs",
+            indexed=12,
+            skipped=0,
+            errors=0,
+            total_vectors=12,
+        )
+        indexer = DocumentIndexer()
+        indexer.save_manifest(stats, sample_records, manifest_path)
+
+        with open(manifest_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert data["version"] == "1.0"
+        assert data["collection"] == "vedaaide_docs"
+        assert len(data["documents"]) == len(sample_records)
+        assert data["documents"][0]["doc_id"] == sample_records[0].doc_id
+
+
+# ---------------------------------------------------------------------------
+# Pipeline integration (load_and_deidentify)
+# ---------------------------------------------------------------------------
+
+
+class TestImportPipeline:
+    def test_load_and_deidentify_returns_records(self) -> None:
+        """load_and_deidentify produces DocumentRecords from sample data."""
+        # pylint: disable-next=import-outside-toplevel
+        from scripts.data.import_deidentified_data import load_and_deidentify
+
+        records = load_and_deidentify(data_dir="data/public_samples")
+        assert len(records) >= 10, "Must produce >= 10 documents"
+
+    def test_all_records_have_content(self) -> None:
+        """Every DocumentRecord must have non-empty content."""
+        # pylint: disable-next=import-outside-toplevel
+        from scripts.data.import_deidentified_data import load_and_deidentify
+
+        records = load_and_deidentify(data_dir="data/public_samples")
+        for rec in records:
+            assert rec.content.strip(), f"Empty content for {rec.doc_id}"
+
+    def test_record_types_are_valid(self) -> None:
+        """All records must have a known doc_type."""
+        # pylint: disable-next=import-outside-toplevel
+        from scripts.data.import_deidentified_data import load_and_deidentify
+
+        valid_types = {"resume", "job_posting", "qa"}
+        records = load_and_deidentify(data_dir="data/public_samples")
+        for rec in records:
+            assert rec.doc_type in valid_types, f"Unknown type '{rec.doc_type}' for {rec.doc_id}"
+
+    def test_verify_deidentification_passes(self) -> None:
+        """Deidentification verification passes on sample data (no synthetic PII)."""
+        # pylint: disable-next=import-outside-toplevel
+        from scripts.data.import_deidentified_data import (
+            load_and_deidentify,
+            verify_deidentification,
+        )
+
+        records = load_and_deidentify(data_dir="data/public_samples")
+        result = verify_deidentification(records)
+        assert result is True


### PR DESCRIPTION
## Summary
Marks Task 1.6 as in-progress and sets up the development branch.

## Changes
- Updated `docs/planning/TASK_BREAKDOWN.cn.md` — marked task 1.6 in-progress, linked issue #16 and branch
- Updated `docs/planning/TASK_BREAKDOWN.en.md` — same (bilingual sync)

## Related Issue
Closes #16

## Checklist
- [x] Branch created from latest main
- [x] Both CN and EN task breakdown files updated
- [ ] Data import pipeline implemented
- [ ] Deidentification applied to sample data
- [ ] Documents indexed in Qdrant
- [ ] Documentation updated