### PR TITLE
feat(data): complete Task 1.4 public sample datasets

### DIFF
--- a/data/public_samples/README.cn.md
+++ b/data/public_samples/README.cn.md
@@ -1,0 +1,205 @@
+# VedaAide 公开示例数据集
+
+## 概览
+
+本目录包含用于 RAG 系统评估、用户测试与开发演示的公开示例数据。所有数据均为合成数据，不包含真实个人隐私信息。
+
+## 数据集组成
+
+### 1. 简历样本（sample_resumes.json）
+
+用途：用于检索、排序与匹配评估。
+
+格式：JSON 数组。
+
+结构示例：
+
+```json
+{
+  "id": "resume_001",
+  "name": "Sample Resume 1",
+  "content": "..."
+}
+```
+
+特点：
+- 共 10 份简历样本
+- 覆盖不同技术方向与资历层级
+- 内容真实风格但均为虚构
+- 适用于检索相关性、相似度匹配、简历解析评估
+
+### 2. 岗位样本（sample_job_postings.json）
+
+用途：用于岗位匹配、相关性排序与需求抽取评估。
+
+格式：JSON 数组。
+
+结构示例：
+
+```json
+{
+  "id": "job_001",
+  "title": "Senior Software Engineer - Backend",
+  "company": "TechCorp Inc",
+  "location": "Remote",
+  "level": "Senior",
+  "salary_min": 150000,
+  "salary_max": 200000,
+  "description": "...",
+  "requirements": [...],
+  "benefits": [...]
+}
+```
+
+特点：
+- 共 10 个岗位样本
+- 覆盖 Junior / Mid / Senior 等级
+- 覆盖工程、产品、数据、运维等方向
+- 适用于岗位-简历匹配、需求抽取、排序评估
+
+### 3. 阅读理解样本（sample_reading_comprehension.json）
+
+用途：用于英文问答与理解能力评估。
+
+格式：JSON 数组。
+
+结构示例：
+
+```json
+{
+  "id": "reading_001",
+  "passage": "...",
+  "question": "...",
+  "options": [...],
+  "correct_answer": "B",
+  "explanation": "..."
+}
+```
+
+特点：
+- 共 5 组阅读理解题
+- 四选一选择题格式
+- 可用于问答质量与解释质量评估
+
+## 数据统计
+
+| 组件 | 数量 | 大小 |
+|------|------|------|
+| 简历 | 10 | ~3.5 KB |
+| 岗位 | 10 | ~7 KB |
+| 阅读理解 | 5 | ~2.5 KB |
+| 总计 | 25 | ~13 KB |
+
+## 使用方式
+
+### Python 代码加载
+
+```python
+import json
+
+# Load resumes
+with open('data/public_samples/sample_resumes.json', 'r') as f:
+    resumes = json.load(f)
+
+# Load job postings
+with open('data/public_samples/sample_job_postings.json', 'r') as f:
+    jobs = json.load(f)
+
+# Load reading comprehension
+with open('data/public_samples/sample_reading_comprehension.json', 'r') as f:
+    questions = json.load(f)
+
+# Use in RAG evaluation
+for resume in resumes:
+    print(f"Resume ID: {resume['id']}")
+    print(f"Content preview: {resume['content'][:100]}...")
+```
+
+### RAG 评估场景
+
+可用于：
+1. 检索效果测试
+2. 排序算法评估（BM25 vs 向量检索）
+3. 问答质量评估
+4. 岗位-简历匹配验证
+
+## 数据扩展建议
+
+1. 按现有 JSON Schema 新增样本。
+2. 保持纯合成数据，不引入真实个人信息。
+3. 更新本文件中的统计信息。
+4. 使用清晰的提交信息记录变更。
+
+## 三层数据策略
+
+### Tier 1：静态样本数据（纳入版本管理）
+
+位置：data/public_samples/（10 份简历，10 份岗位，5 份 QA）
+
+```python
+from src.core.data import DataLoader
+
+loader = DataLoader(source="static")
+resumes = loader.get_resumes()        # 10 samples
+jobs = loader.get_jobs()              # 10 samples
+qa_pairs = loader.get_qa_pairs()      # 5 samples
+```
+
+特点：
+- 始终可用、无外部依赖
+- 加载快
+- 适合演示与快速验证
+
+### Tier 2：合成数据生成（开发与测试）
+
+位置：scripts/data/data_generator.py（数量可配置）
+
+```python
+from src.core.data import DataLoader
+
+# Generate 1000 resumes and 1000 jobs
+loader = DataLoader(source="generated", seed=42)
+resumes = loader.get_resumes(count=1000)
+jobs = loader.get_jobs(count=1000)
+
+# Or generate with different seed for variety
+loader2 = DataLoader(source="generated", seed=123)
+more_jobs = loader2.get_jobs(count=500)
+```
+
+命令行示例：
+
+```bash
+# Generate to JSON
+python scripts/data/data_generator.py \
+  --resumes 1000 \
+  --jobs 1000 \
+  --output-dir data/working_datasets \
+  --format json \
+  --seed 42
+
+# Generate to JSONL (better for large datasets)
+python scripts/data/data_generator.py \
+  --resumes 10000 \
+  --jobs 10000 \
+  --output-dir data/working_datasets \
+  --format jsonl
+```
+
+### Tier 3：公共真实数据集（评估）
+
+位置：按需从 Kaggle、Hugging Face 或 GitHub 下载。
+
+```python
+from src.core.data import DataLoader
+
+# From Kaggle (requires API key setup)
+loader = DataLoader(source="kaggle", dataset_id="...")
+jobs = loader.get_jobs(count=100000)
+
+# From Hugging Face Hub
+loader = DataLoader(source="huggingface", repo_id="...")
+resumes = loader.get_resumes(count=50000)
+```
+
+更多细节可参考英文版：[README.md](README.md)。

--- a/data/public_samples/README.md
+++ b/data/public_samples/README.md
@@ -22,7 +22,7 @@ This directory contains publicly available sample datasets designed for RAG syst
 ```
 
 **Characteristics**:
-- 5 sample resumes covering different seniority levels
+- 10 sample resumes covering different seniority levels
 - Diverse technical backgrounds (Backend, Product, Data Science, DevOps, Frontend)
 - Realistic but fictional professional experiences
 - Well-structured with skills, experience, and accomplishments sections
@@ -51,7 +51,7 @@ This directory contains publicly available sample datasets designed for RAG syst
 ```
 
 **Characteristics**:
-- 5 diverse job postings
+- 10 diverse job postings
 - Different job levels (Junior, Mid, Senior)
 - Various departments (Engineering, Product, Data Science, DevOps)
 - Realistic salary ranges and benefits
@@ -86,10 +86,10 @@ This directory contains publicly available sample datasets designed for RAG syst
 
 | Component | Count | Size |
 |-----------|-------|------|
-| Resumes | 5 | ~1.5 KB |
-| Job Postings | 5 | ~3 KB |
+| Resumes | 10 | ~3.5 KB |
+| Job Postings | 10 | ~7 KB |
 | Reading Questions | 5 | ~2.5 KB |
-| **Total** | **15** | **~7 KB** |
+| **Total** | **25** | **~13 KB** |
 
 ## Usage
 
@@ -149,21 +149,21 @@ VedaAide supports a **three-tier data strategy** to balance quick development wi
 
 ### 🎯 Tier 1: Static Sample Data (Committed to Git)
 
-**Location**: `data/public_samples/` (5 samples per type)
+**Location**: `data/public_samples/` (10 resumes, 10 jobs, 5 QA pairs)
 
 ```python
 from src.core.data import DataLoader
 
 loader = DataLoader(source="static")
-resumes = loader.get_resumes()        # 5 samples
-jobs = loader.get_jobs()              # 5 samples
+resumes = loader.get_resumes()        # 10 samples
+jobs = loader.get_jobs()              # 10 samples
 qa_pairs = loader.get_qa_pairs()      # 5 samples
 ```
 
 **Characteristics**:
 - ✅ Always available, zero dependencies
 - ✅ Fast (instant load)
-- ✅ Small (~7 KB total)
+- ✅ Small (~13 KB total)
 - ✅ Suitable for demos and documentation
 - ❌ Too small for comprehensive testing
 

--- a/data/public_samples/sample_job_postings.json
+++ b/data/public_samples/sample_job_postings.json
@@ -133,5 +133,135 @@
       "Health and wellness programs",
       "Casual work environment"
     ]
+  },
+  {
+    "id": "job_006",
+    "title": "Machine Learning Engineer",
+    "company": "VisionLab AI",
+    "location": "Boston, MA",
+    "level": "Senior",
+    "salary_min": 145000,
+    "salary_max": 195000,
+    "description": "Join our applied AI team to design, train, and deploy machine learning models for high-impact business scenarios. You will work across model lifecycle management, data quality, and production observability.",
+    "requirements": [
+      "5+ years of ML engineering experience",
+      "Strong Python and SQL skills",
+      "Hands-on experience with PyTorch or TensorFlow",
+      "Experience deploying models to production",
+      "Understanding of feature stores and MLOps workflows",
+      "Strong communication and collaboration skills"
+    ],
+    "benefits": [
+      "Base salary + annual performance bonus",
+      "Equity package",
+      "Comprehensive health coverage",
+      "Home office stipend",
+      "Learning budget and conference support",
+      "Flexible hybrid schedule"
+    ]
+  },
+  {
+    "id": "job_007",
+    "title": "Mobile Engineer - iOS/Android",
+    "company": "FinFlow Mobile",
+    "location": "Remote",
+    "level": "Mid-level",
+    "salary_min": 115000,
+    "salary_max": 155000,
+    "description": "We are building next-generation mobile banking experiences. You will collaborate with product and design to deliver secure, performant, and user-friendly mobile features for millions of users.",
+    "requirements": [
+      "3+ years of mobile engineering experience",
+      "Strong Kotlin or Swift development skills",
+      "Experience with mobile app architecture patterns",
+      "Understanding of secure mobile development practices",
+      "Experience with testing and release automation",
+      "Ability to collaborate in cross-functional teams"
+    ],
+    "benefits": [
+      "Competitive compensation and equity",
+      "Remote-first team",
+      "Health and wellness allowance",
+      "Parental leave",
+      "Annual team offsite",
+      "Career growth mentorship"
+    ]
+  },
+  {
+    "id": "job_008",
+    "title": "QA Automation Engineer",
+    "company": "QualityScale Systems",
+    "location": "Denver, CO",
+    "level": "Mid-level",
+    "salary_min": 100000,
+    "salary_max": 140000,
+    "description": "Help us build robust quality automation for a microservices platform. You will design end-to-end test strategies, improve test reliability, and integrate quality gates into CI/CD pipelines.",
+    "requirements": [
+      "4+ years in QA or test automation",
+      "Experience with Playwright, Cypress, or Selenium",
+      "Strong API testing skills",
+      "Familiarity with CI/CD tooling",
+      "Understanding of test pyramid and risk-based testing",
+      "Ability to analyze and reduce flaky tests"
+    ],
+    "benefits": [
+      "Competitive salary",
+      "Health, dental, and vision insurance",
+      "Flexible paid time off",
+      "401k matching",
+      "Certification reimbursement",
+      "Ergonomic equipment stipend"
+    ]
+  },
+  {
+    "id": "job_009",
+    "title": "Security Engineer - Application Security",
+    "company": "SecureStack Labs",
+    "location": "Chicago, IL",
+    "level": "Senior",
+    "salary_min": 150000,
+    "salary_max": 205000,
+    "description": "We are seeking an AppSec engineer to embed security into product development. You will lead threat modeling, secure coding initiatives, and vulnerability remediation workflows across multiple teams.",
+    "requirements": [
+      "6+ years of security engineering experience",
+      "Strong knowledge of OWASP Top 10 and secure SDLC",
+      "Experience with SAST/DAST and dependency scanning",
+      "Ability to conduct threat modeling and risk assessments",
+      "Scripting skills in Python or Bash",
+      "Strong incident response collaboration skills"
+    ],
+    "benefits": [
+      "Top market compensation",
+      "Annual bonus",
+      "Equity participation",
+      "Comprehensive insurance package",
+      "Education and certification budget",
+      "Flexible remote policy"
+    ]
+  },
+  {
+    "id": "job_010",
+    "title": "Data Engineer - Streaming Platform",
+    "company": "DataStream Works",
+    "location": "Toronto, ON",
+    "level": "Senior",
+    "salary_min": 135000,
+    "salary_max": 185000,
+    "description": "Build and operate a real-time data platform that powers product analytics and decision systems. You will own streaming pipelines, schema management, and performance optimization of large-scale data workloads.",
+    "requirements": [
+      "5+ years of data engineering experience",
+      "Strong experience with Kafka and Spark or Flink",
+      "Proficiency in SQL and Python",
+      "Experience with cloud data warehouses",
+      "Understanding of data modeling and data contracts",
+      "Experience building observability for data pipelines"
+    ],
+    "benefits": [
+      "Competitive salary package",
+      "Annual bonus and stock options",
+      "Comprehensive health benefits",
+      "Remote and flexible work arrangement",
+      "Professional development allowance",
+      "Wellness and mental health support"
+    ]
   }
 ]

--- a/data/public_samples/sample_resumes.json
+++ b/data/public_samples/sample_resumes.json
@@ -23,5 +23,30 @@
     "id": "resume_005",
     "name": "Sample Resume 5",
     "content": "Frontend Engineer with 4 years of experience building responsive web applications. Expertise in modern JavaScript frameworks and CSS. Focus on performance optimization and user experience.\n\nTechnologies:\n- JavaScript Frameworks: React, Vue.js, Angular\n- Styling: CSS3, SASS, Tailwind CSS, Material-UI\n- Build Tools: Webpack, Vite, Parcel\n- Testing: Jest, React Testing Library, Cypress\n- Performance: Web Vitals optimization, Code splitting\n\nProjects:\n- Redesigned company dashboard reducing load time by 60%\n- Implemented component library used across 10+ applications\n- Led performance optimization initiative improving accessibility score to 98"
+  },
+  {
+    "id": "resume_006",
+    "name": "Sample Resume 6",
+    "content": "Machine Learning Engineer with 6 years of experience building production-grade AI systems. Strong background in model deployment, feature engineering, and MLOps. Experienced in collaborating with product and platform teams to deliver measurable business impact.\n\nTechnical Skills:\n- Languages: Python, SQL, Java\n- ML: PyTorch, TensorFlow, Scikit-learn, LightGBM\n- MLOps: MLflow, Kubeflow, Airflow, Docker\n- Data Platforms: Spark, BigQuery, Snowflake\n- APIs: FastAPI, gRPC\n\nExperience:\n- VisionLab AI (2021-Present): Built anomaly detection models reducing fraud losses by 22%\n- SmartRetail (2018-2021): Deployed recommendation service improving conversion by 18%\n- QuantData (2017-2018): Developed feature pipelines for weekly retraining workflows"
+  },
+  {
+    "id": "resume_007",
+    "name": "Sample Resume 7",
+    "content": "Mobile Engineer with 5 years of experience developing iOS and Android applications at scale. Focused on app architecture, offline-first experiences, and performance tuning. Passionate about delivering accessible and intuitive mobile products.\n\nCore Skills:\n- Languages: Kotlin, Swift, Dart\n- Frameworks: Android SDK, iOS UIKit, Flutter\n- Architecture: MVVM, Clean Architecture\n- Tooling: Firebase, Crashlytics, Fastlane\n- Testing: XCTest, Espresso, Widget tests\n\nHighlights:\n- Launched fintech app used by 2M monthly users\n- Improved startup performance by 40% through app modularization\n- Introduced release automation reducing deployment errors by 70%"
+  },
+  {
+    "id": "resume_008",
+    "name": "Sample Resume 8",
+    "content": "QA Automation Engineer with 7 years of experience in quality engineering for web and backend systems. Specialized in automation strategy, flaky test reduction, and CI test acceleration. Works closely with development teams to shift quality left.\n\nExpertise:\n- Automation: Playwright, Selenium, Cypress, Pytest\n- API Testing: Postman, REST Assured\n- CI/CD: Jenkins, GitHub Actions\n- Performance: k6, JMeter\n- Quality Practices: Test pyramid, contract testing\n\nAchievements:\n- Increased automation coverage from 35% to 82% in one year\n- Reduced flaky tests by 60% via isolation and retry strategy redesign\n- Built quality dashboards that cut regression triage time in half"
+  },
+  {
+    "id": "resume_009",
+    "name": "Sample Resume 9",
+    "content": "Security Engineer with 8 years of experience in application security and cloud security architecture. Skilled in threat modeling, vulnerability management, and secure SDLC practices. Drives security adoption through engineering enablement and tooling.\n\nSecurity Stack:\n- AppSec: SAST, DAST, dependency scanning\n- Cloud Security: IAM hardening, network segmentation, KMS\n- Standards: OWASP ASVS, ISO 27001, SOC 2\n- Tooling: Burp Suite, Trivy, Semgrep\n- Languages: Python, Bash\n\nImpact:\n- Implemented security gates reducing critical vulnerabilities in release builds by 75%\n- Led incident response tabletop program across 4 product teams\n- Established secure coding training completed by 120+ engineers"
+  },
+  {
+    "id": "resume_010",
+    "name": "Sample Resume 10",
+    "content": "Data Engineer with 6 years of experience designing reliable batch and streaming data platforms. Strong in distributed systems, data modeling, and observability for data pipelines. Known for improving data freshness and platform stability.\n\nTechnical Skills:\n- Data Processing: Spark, Flink, Kafka\n- Warehousing: Snowflake, Redshift, BigQuery\n- Orchestration: Airflow, Dagster\n- Infrastructure: Terraform, Kubernetes\n- Languages: Python, SQL, Scala\n\nProjects:\n- Built CDC pipeline reducing analytics latency from 24 hours to 20 minutes\n- Implemented schema governance reducing data contract incidents by 45%\n- Migrated legacy ETL to streaming architecture for near real-time reporting"
   }
 ]

--- a/tests/integration/test_data_import.py
+++ b/tests/integration/test_data_import.py
@@ -166,7 +166,18 @@ class TestImportPipeline:
         from scripts.data.import_deidentified_data import load_and_deidentify
 
         records = load_and_deidentify(data_dir="data/public_samples")
-        assert len(records) >= 10, "Must produce >= 10 documents"
+        assert len(records) >= 20, "Must produce >= 20 documents"
+
+    def test_public_samples_have_minimum_resume_and_job_counts(self) -> None:
+        """Task 1.4 requires at least 10 resumes and 10 job postings."""
+        from scripts.data.import_deidentified_data import load_and_deidentify
+
+        records = load_and_deidentify(data_dir="data/public_samples")
+        resume_count = sum(1 for rec in records if rec.doc_type == "resume")
+        job_count = sum(1 for rec in records if rec.doc_type == "job_posting")
+
+        assert resume_count >= 10, "Must include >= 10 resume records"
+        assert job_count >= 10, "Must include >= 10 job posting records"
 
     def test_all_records_have_content(self) -> None:
         """Every DocumentRecord must have non-empty content."""


### PR DESCRIPTION
## Summary
Complete Task 1.4 by expanding public sample datasets and aligning validation and documentation.

## Changes
- Expand data/public_samples/sample_resumes.json from 5 to 10 resumes.
- Expand data/public_samples/sample_job_postings.json from 5 to 10 job postings.
- Update data/public_samples/README.md counts and usage notes.
- Add Chinese counterpart data/public_samples/README.cn.md.
- Strengthen integration checks in tests/integration/test_data_import.py:
  - minimum total records >= 20 for import pipeline;
  - explicit assertions for >=10 resume and >=10 job_posting records.

## Verification
- Ran: poetry run pytest tests/integration/test_data_import.py -q
- Result: 14 passed

## Task Mapping
- Task 1.4 acceptance criteria are covered: public datasets prepared, documented, and verified with deidentification pipeline tests.
